### PR TITLE
Avoid emitting links too closely in time.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,5 @@ WORKDIR /home/hubot
 # HUBOT_GITHUB_PASSWORD
 #
 CMD bin/hubot -a slack
-ARG VERSION="0.5.4"
+ARG VERSION="0.5.5"
 LABEL version="$VERSION"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqrbot",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "private": true,
   "author": "Adam Thornton <athornton@lsst.org>",
   "description": "DM-SQuaRE Automation",

--- a/scripts/linkticket.coffee
+++ b/scripts/linkticket.coffee
@@ -32,6 +32,11 @@ issueResponses = (robot, msg) ->
   ticketIds = Array.from(new Set(msg.match))
   for ticketId in ticketIds
     ticketId = ticketId.toUpperCase()
+    last = robot.brain.get(ticketId)
+    now = moment()
+    robot.brain.set(ticketId, now)
+    if last and now.isBefore last.add(1, 'minute')
+      return
     urlstr="https://jira.lsstcorp.org/rest/api/latest/issue/#{ticketId}"
     robot.http(urlstr).get() (err, res, body) ->
       if res.statusCode in [401, 403]


### PR DESCRIPTION
Use robot.brain to store the last time each ticket has been seen; if
that's too recent, avoid emitting a new link.