### PR TITLE
Improve JIRA link messages

### DIFF
--- a/scripts/linkticket.coffee
+++ b/scripts/linkticket.coffee
@@ -5,6 +5,7 @@ moment = require("moment")
 {TextMessage} = require("hubot/src/message")
 
 BOT_NAMES = ["jirabot"]
+TICKET_PREFIXES = "DM|RFC|ITRFC|IHS|PUB"
 
 module.exports = (robot) ->
   rootCas = require('ssl-root-cas/latest').create()
@@ -14,7 +15,17 @@ module.exports = (robot) ->
     # Matcher
     (message) ->
       if message instanceof TextMessage
-        match = message.match(/\b(DM|RFC|ITRFC|IHS|PUB)-\d+/gi)
+        txt = message.text
+        # Remove code blocks (approximately)
+        txt = txt.replace(/```[^`]+```/, "")
+        # Remove URLs and pathnames (approximately)
+        txt = txt.replace(///
+          \/(#{TICKET_PREFIXES})
+          ///gi, "")
+        # Match any ticket identifiers that are left
+        match = txt.match(///
+          \b(#{TICKET_PREFIXES})-\d+
+          ///gi)
         if match and message.user.name not in BOT_NAMES
           match
         else

--- a/scripts/linkticket.coffee
+++ b/scripts/linkticket.coffee
@@ -46,7 +46,7 @@ issueResponses = (robot, msg) ->
     last = robot.brain.get(ticketId)
     now = moment()
     robot.brain.set(ticketId, now)
-    if last and now.isBefore last.add(1, 'minute')
+    if last and now.isBefore last.add(5, 'minute')
       return
     urlstr="https://jira.lsstcorp.org/rest/api/latest/issue/#{ticketId}"
     robot.http(urlstr,{ecdhCurve: 'auto'}).get() (err, res, body) ->

--- a/scripts/linkticket.coffee
+++ b/scripts/linkticket.coffee
@@ -18,6 +18,8 @@ module.exports = (robot) ->
         txt = message.text
         # Remove code blocks (approximately)
         txt = txt.replace(/```[^`]+```/, "")
+        # Remove inline code
+        txt = txt.replace(/`[^`]+`/, "")
         # Remove URLs and pathnames (approximately)
         txt = txt.replace(///
           \/(#{TICKET_PREFIXES})


### PR DESCRIPTION
Some minor tweaks:

- do not insert a link for ticket names in paths and URLs
- do not insert a link for ticket names in triple-backquote code blocks
- do not insert a link for ticket names in inline code
- do not insert a link if the same link has been inserted within the last 5 minutes (up from current 1 minute)
